### PR TITLE
Add patch for Helm 3.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,10 @@ RUN apk add --update \
 
 # Install helmfile plugin deps
 
-RUN helm plugin install https://github.com/databus23/helm-diff --version ${HELM_DIFF_VERSION} && \
-    helm plugin install ${HELM_SECRETS_IMAGE} --version ${HELM_SECRETS_VERSION}
+RUN helm plugin install https://github.com/databus23/helm-diff --version ${HELM_DIFF_VERSION}
+RUN rm -rf /root/.helm/helm/plugins/https-github.com*
+RUN helm plugin install ${HELM_SECRETS_IMAGE} --version ${HELM_SECRETS_VERSION}
+RUN rm -rf /root/.helm/helm/plugins/https-github.com*
 
 # Install helmfile
 


### PR DESCRIPTION
For Helm `3.9.0`, when installing the `helm-diff` and `helm-secrets` plugins, duplicate plugin locations are installed:

For example:
```
bash-5.1# helm plugin install https://github.com/databus23/helm-diff
failed to load plugins: two plugins claim the name "diff" at "/root/.helm/helm/plugins/helm-diff" and "/root/.helm/helm/plugins/https-github.com-databus23-helm-diff"
Downloading https://github.com/databus23/helm-diff/releases/latest/download/helm-diff-linux-amd64.tgz
```

This PR is a patch to remove the plugins under `/root/.helm/helm/plugins/https-github.com*` but retain the plugins under `"/root/.helm/helm/plugins/helm-*`.